### PR TITLE
Fix incorrect error message after running

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -182,7 +182,7 @@ restartBoot2Docker()
 # @return:  'true', if NFS is mounted; else 'false'  
 isNFSMounted()
 {
-    local nfs_mount=$(docker-machine ssh $prop_machine_name df | grep "$prop_machine_vboxnet_ip:/Users")
+    local nfs_mount=$(docker-machine ssh $prop_machine_name "df || true" | grep "$prop_machine_vboxnet_ip:/Users")
     if [ "" = "$nfs_mount" ]; then echo "false"; else echo "true"; fi
 }
 


### PR DESCRIPTION
The script would say `[INFO] Verify NFS mount ... FAIL` even though it
was perfectly fine.

The reason was that `docker-machine ssh <machine-name> df` returned
only: `exit status 1`

This seems to be related to some aufs-related file systems where df
gets a "permission denied". Stuff like this:

```
none                     18.2G      4.2G     13.0G  24% /mnt/sda1/var/lib/docker/aufs/mnt/d52aab1e7fec612742470b048dc9baf4887c8c52dba430d106a0e72e426f502f
df: /var/run/docker/netns/d52aab1e7fec: Permission denied
```

I fixed this by making the df command always return with exit status 0.
