### PR TITLE
Fix bootlocal.sh interpreter line

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -22,6 +22,7 @@
 # THE SOFTWARE.
 #
 
+set -x
 set -o errexit
 
 # BEGIN _functions
@@ -157,7 +158,7 @@ configureBoot2Docker()
     # render bootlocal.sh and copy bootlocal.sh over to boot2docker
     # (this will override an existing /var/lib/boot2docker/bootlocal.sh)
     
-    local bootlocalsh='#/bin/bash
+    local bootlocalsh='#!/bin/sh
     sudo umount /Users
     sudo /usr/local/etc/init.d/nfs-client start
     sudo mount -t nfs -o noacl,async '$prop_machine_vboxnet_ip':/Users /Users'
@@ -190,6 +191,7 @@ isNFSMounted()
 verifyNFSMount()
 {
     echoInfo "Verify NFS mount ... \t\t\t"
+    sleep 10
     
     if [ "$(isNFSMounted)" = "false" ]; then
         echoError "Cannot detect the NFS mount :("; exit 1

--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -190,7 +190,6 @@ isNFSMounted()
 verifyNFSMount()
 {
     echoInfo "Verify NFS mount ... \t\t\t"
-    sleep 10
     
     if [ "$(isNFSMounted)" = "false" ]; then
         echoError "Cannot detect the NFS mount :("; exit 1

--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -22,7 +22,6 @@
 # THE SOFTWARE.
 #
 
-set -x
 set -o errexit
 
 # BEGIN _functions


### PR DESCRIPTION
This fixes the interpreter (shebang) line in the bootlocal.sh script, as well as changing shell to `/bin/sh` as bash does not appear to be included in boot2docker.

Furthermore my local version (outside of this PR) includes the `sleep 10` in bootlocal.sh as well as right before the NFS verification. Without the sleep in bootlocal.sh I was getting a Network Unavailable error in `/var/log/bootlocal.log`, and without the sleep in the NFS verification it's check would happen before bootlocal.sh completed.

FWIW I'm using docker-machine 0.4.1 and boot2docker 1.8.0.
