### PR TITLE
Added basic vmwarefusion support and shared folder aliases (adds to PR 18)

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -132,7 +132,7 @@ parseCli()
   fi;
 
   if [ ${#prop_shared_folder_aliases[@]} -eq 0 ]; then
-    prop_shared_folder_aliases=prop_shared_folders
+    prop_shared_folder_aliases=$prop_shared_folders
   fi;
 
   echoInfo "Configuration:"

--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -309,7 +309,6 @@ configureBoot2Docker()
     bootlocalsh="${bootlocalsh}
     sudo mount -t nfs -o noacl,async "$prop_nfshost_ip":"$shared_folder" "${prop_shared_folder_aliases[ALIAS_COUNTER]}
     let ALIAS_COUNTER=ALIAS_COUNTER+1
-    echo $ALIAS_COUNTER
   done
 
   local file="/var/lib/boot2docker/bootlocal.sh"

--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -123,6 +123,19 @@ lookupMandatoryProperties ()
 
   prop_machine_driver=$(getMachineDriver $1)
 
+  if [ "$prop_machine_driver" = "vmwarefusion" ]; then
+    prop_network_id="Shared"
+
+    prop_nfshost_ip=$(ifconfig -m `route get 8.8.8.8 | awk '{if ($1 ~ /interface:/){print $2}}'` | awk 'sub(/inet /,""){print $1}')
+    prop_machine_ip=$prop_nfshost_ip
+    if [ "" = "${prop_nfshost_ip}" ]; then
+      echoError "Could not find the vmware fusion net IP!"; exit 1
+    fi
+
+    echoSuccess "OK"
+    return
+  fi
+
   if [ "$prop_machine_driver" = "parallels" ]; then
     prop_network_id="Shared"
     prop_nfshost_ip=$(prlsrvctl net info \

--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -141,13 +141,17 @@ parseCli()
   echo #EMPTY
 
   echoProperties "Machine Name: $prop_machine_name"
+  SHARE_COUNTER=1
   for shared_folder in "${prop_shared_folders[@]}"
   do
-    echoProperties "Shared Folder: $shared_folder"
+    echoProperties "Shared Folder $SHARE_COUNTER: $shared_folder"
+    let SHARE_COUNTER=SHARE_COUNTER+1
   done
+  ALIAS_COUNTER=1
   for shared_folder_alias in "${prop_shared_folder_aliases[@]}"
   do
-    echoProperties "Shared Folder Alias: $shared_folder_alias"
+    echoProperties "Shared Folder Alias $ALIAS_COUNTER: $shared_folder_alias"
+    let ALIAS_COUNTER=ALIAS_COUNTER+1
   done
   echoProperties "Force: $prop_force_configuration_nfs"
 


### PR DESCRIPTION
Hi, I this works with the basic NAT setup that docker-machine/vmware fusion seems to use, and solves the problem of NFS + VMWare fusion for me.

Support for alternative ways of getting the mount host ip may be possible with commands via 'vmrun' (kinda like VBoxManage) but a fair big of searching didn't find the right thing for me. 

Closest I got was `prop_nfshost_ip=$(vmrun getGuestIPAddress $(vmrun list $1 | grep "$1.vmx"))` but then I realised I need the host ip, not the guest IP. 

And the above requires the user to setup a symlink to vmrun like this:

  `sudo ln -s "/Applications/VMware Fusion.app/Contents/Library/vmrun" /usr/local/bin/vmrun`

Might partially resolve https://github.com/adlogix/docker-machine-nfs/issues/21 at least for the most common use case of NAT vmware fusion and docker-machine nfs.

Note: for some reason the bootlocal.sh `sudo umount /Users` never seems to actually unmount the vmware fusion default hgfs, but the more recent NFS mount overrides it anyway.

Also I had to add `nfs.server.mount.require_resv_port = 0` to OSX /etc/nfs.conf otherwise I got a NFS mount error about weak credentials. This is referenced in 'another' docker-machine-nfs.sh in their code here: https://gist.github.com/olalonde/3f7512c0bd2bc8abb46d so it might be worth adding that too. That's where I got the command for getting prop_nfshost_ip, thanks @DavidStaron. Hope this saves someone some time. Here's hoping vmwarefusion has some performance benefits over virtualbox for all this effort :)

Cheers,
Christiaan Kortekaas
