### PR TITLE
Allow to configure the nfs options + improve usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,27 @@ curl https://raw.githubusercontent.com/adlogix/docker-machine-nfs/master/docker-
 ## Usage
 
 ```sh
-docker-machine-nfs <machine-name> [--shared-folder=/Users,...] [--force]
+Usage: ./docker-machine-nfs.sh <machine-name> [options]
+
+Options:
+  
+  -f, --force               Force reconfiguration of nfs
+  -n, --nfs-config          NFS configuration to use in /etc/exports. (default to '-alldirs -mapall=$(id -u):$(id -g)')
+  -s, --shared-folder,...   Folder to share (default to /Users)
+  
+Examples:
+
+  $ docker-machine-nfs test
+  
+    > Configure the /Users folder with NFS
+  
+  $ docker-machine-nfs test --shared-folder=/Users --shared-folder=/var/www
+  
+    > Configures the /Users and /var/www folder with NFS
+    
+  $ docker-machine-nfs test --shared-folder=/var/www --nfs-config="-alldirs -maproot=0"
+  
+    > Configure the /var/www folder with NFS and the options '-alldirs -maproot=0'
 ```
 
 ## Demo


### PR DESCRIPTION
fixes #17 

I'll leave it open for those who want to test first. Copy of the usage:

``` sh
Usage: ./docker-machine-nfs.sh <machine-name> [options]

Options:

  -f, --force               Force reconfiguration of nfs
  -n, --nfs-config          NFS configuration to use in /etc/exports. (default to '-alldirs -mapall=$(id -u):$(id -g)')
  -s, --shared-folder,...   Folder to share (default to /Users)

Examples:

  $ docker-machine-nfs test

    > Configure the /Users folder with NFS

  $ docker-machine-nfs test --shared-folder=/Users --shared-folder=/var/www

    > Configures the /Users and /var/www folder with NFS

  $ docker-machine-nfs test --shared-folder=/var/www --nfs-config="-alldirs -maproot=0"

    > Configure the /var/www folder with NFS and the options '-alldirs -maproot=0'
```
