### PR TITLE
Use `curl -s` to install the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ existing boot2docker box created through
 ## Install
 
 ```sh
-curl https://raw.githubusercontent.com/adlogix/docker-machine-nfs/master/docker-machine-nfs.sh |
+curl -s https://raw.githubusercontent.com/adlogix/docker-machine-nfs/master/docker-machine-nfs.sh |
   sudo tee /usr/local/bin/docker-machine-nfs > /dev/null && \
   sudo chmod +x /usr/local/bin/docker-machine-nfs
 ```


### PR DESCRIPTION
This is so the `Password:` prompt doesn't look dumb:

Ugly:

``` bash
$ curl https://raw.githubusercontent.com/adlogix/docker-machine-nfs/master/docker-machine-nfs.s
h |   sudo tee /usr/local/bin/docker-machine-nfs > /dev/null &&  sudo chmod +x /usr/local/bin/docker-machine-nfs
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 10974  100 10974    0     0  34967      0 --:--:-- --:--:-- --:--:-- 35060Password:
```

Pretty:

``` bash
$ curl -s https://raw.githubusercontent.com/adlogix/docker-machine-nfs/master/docker-machine-nfs.sh |   sudo tee /usr/local/bin/docker-machine-nfs > /dev/null &&  sudo chmod +x /usr/local/bin/docker-machine-nfs
Password:
```
