### PR TITLE
Run sync to ensure bootlocal.sh is written to disk

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -336,9 +336,9 @@ configureBoot2Docker()
   local file="/var/lib/boot2docker/bootlocal.sh"
 
   docker-machine ssh $prop_machine_name \
-    "echo '$bootlocalsh' | sudo tee $file && sudo chmod +x $file" > /dev/null
+    "echo '$bootlocalsh' | sudo tee $file && sudo chmod +x $file && sync" > /dev/null
 
-  sleep 20
+  sleep 2
 
   echoSuccess "OK"
 }


### PR DESCRIPTION
This should fix issue #31. The two second sleep is recommended by
http://linux.die.net/man/8/sync
