### PR TITLE
Support for xhyve

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ curl https://raw.githubusercontent.com/adlogix/docker-machine-nfs/master/docker-
 * Virtualbox
 * Paralells
 * VMware Fusion
+* xhyve
 
 ## Usage
 
@@ -29,23 +30,23 @@ curl https://raw.githubusercontent.com/adlogix/docker-machine-nfs/master/docker-
 Usage: ./docker-machine-nfs.sh <machine-name> [options]
 
 Options:
-  
+
   -f, --force               Force reconfiguration of nfs
   -n, --nfs-config          NFS configuration to use in /etc/exports. (default to '-alldirs -mapall=$(id -u):$(id -g)')
   -s, --shared-folder,...   Folder to share (default to /Users)
-  
+
 Examples:
 
   $ docker-machine-nfs test
-  
+
     > Configure the /Users folder with NFS
-  
+
   $ docker-machine-nfs test --shared-folder=/Users --shared-folder=/var/www
-  
+
     > Configures the /Users and /var/www folder with NFS
-    
+
   $ docker-machine-nfs test --shared-folder=/var/www --nfs-config="-alldirs -maproot=0"
-  
+
     > Configure the /var/www folder with NFS and the options '-alldirs -maproot=0'
 ```
 

--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -241,6 +241,16 @@ lookupMandatoryProperties ()
     return
   fi
 
+  if [ "$prop_machine_driver" = "xhyve" ]; then
+    prop_network_id="Shared"
+    prop_nfshost_ip=$(ifconfig -m `route get $prop_machine_ip | awk '{if ($1 ~ /interface:/){print $2}}'` | awk 'sub(/inet /,""){print $1}')
+    if [ "" = "${prop_nfshost_ip}" ]; then
+      echoError "Could not find the xhyve net IP!"; exit 1
+    fi
+    echoSuccess "OK"
+    return
+  fi
+
   if [ "$prop_machine_driver" = "parallels" ]; then
     prop_network_id="Shared"
     prop_nfshost_ip=$(prlsrvctl net info \


### PR DESCRIPTION
This is a working attempt at updating the script to support the xhyve vm driver.

It works by doing a lookup of the bridge interface created by xhyve and using that as the nfshost ip

Tested on OS X 10.11.3 with:
docker-machine 0.6.0
xhyve 0.2.0
docker-machine-driver-xhyve 0.2.2

(all installed w/ homebrew)
