### PR TITLE
submitted a Homebrew formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,20 @@ existing boot2docker box created through
 
 ## Install
 
+### Standalone
+
 ```sh
 curl -s https://raw.githubusercontent.com/adlogix/docker-machine-nfs/master/docker-machine-nfs.sh |
   sudo tee /usr/local/bin/docker-machine-nfs > /dev/null && \
   sudo chmod +x /usr/local/bin/docker-machine-nfs
 ```
+
+### [Homebrew](http://brew.sh/)
+
+```sh
+brew install docker-machine-nfs
+```
+
 
 ## Supports
 


### PR DESCRIPTION
I've submitted a Homebrew formula (Homebrew/homebrew#49920) for
docker-machine-nfs.  Homebrew wants packages to have versioned releases,
though; would you consider releasing another tagged version so that I
can update the formula?

This PR should probably not be merged until the Homebrew formula is
merged.
