### PR TITLE
Fix and improve /etc/exports updates

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -328,31 +328,31 @@ configureNFS()
 
   echoWarn "\n !!! Sudo will be necessary for editing /etc/exports !!!"
 
-	#-- Update the /etc/exports file and restart nfsd
+  #-- Update the /etc/exports file and restart nfsd
 
-	local exports_begin="# docker-machine-nfs-begin $prop_machine_name"
-	local exports_end="# docker-machine-nfs-end $prop_machine_name"
+  local exports_begin="# docker-machine-nfs-begin $prop_machine_name"
+  local exports_end="# docker-machine-nfs-end $prop_machine_name"
 
-	# Remove old docker-machine-nfs exports
-	local exports=$(cat /etc/exports | \
-		tr "\n" "\r" | \
-		sed "s/${exports_begin}.*${exports_end}//" | \
-		tr "\r" "\n"
-	)
+  # Remove old docker-machine-nfs exports
+  local exports=$(cat /etc/exports | \
+    tr "\n" "\r" | \
+    sed "s/${exports_begin}.*${exports_end}//" | \
+    tr "\r" "\n"
+  )
 
-	# Write new exports blocks beginning
-	exports="${exports}\n${exports_begin}\n"
+  # Write new exports blocks beginning
+  exports="${exports}\n${exports_begin}\n"
 
   for shared_folder in "${prop_shared_folders[@]}"
   do
-		# Add new exports
-		exports="${exports}$shared_folder $prop_machine_ip $prop_nfs_config\n"
+    # Add new exports
+    exports="${exports}$shared_folder $prop_machine_ip $prop_nfs_config\n"
   done
 
-	# Write new exports block ending
-	exports="${exports}${exports_end}"
-	#Export to file
-	echo "$exports" | sudo tee /etc/exports >/dev/null
+  # Write new exports block ending
+  exports="${exports}${exports_end}"
+  #Export to file
+  echo "$exports" | sudo tee /etc/exports >/dev/null
 
   sudo nfsd restart ; sleep 2 && sudo nfsd checkexports
 

--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -421,8 +421,8 @@ isNFSMounted()
 {
   for shared_folder in "${prop_shared_folders[@]}"
   do
-    local nfs_mount=$(docker-machine ssh $prop_machine_name "sudo df" |
-      grep "$prop_nfshost_ip:$prop_shared_folders")
+    local nfs_mount=$(docker-machine ssh $prop_machine_name "sudo mount" |
+      grep "$prop_nfshost_ip:$prop_shared_folders on")
     if [ "" = "$nfs_mount" ]; then
       echo "false";
       return;


### PR DESCRIPTION
Fixes:
- Propery remove old bindings from /etc/exports (not just check for duplicates)
- Fix bug that boot2docker configuration was not updated properly in some cases

Improvements:
- Make exports bindings machine dependent (so that removing bindings for one machine would not affect other)
