### PR TITLE
Append version command to report script version

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -26,6 +26,11 @@ set -o errexit
 
 # BEGIN _functions
 
+version ()
+{
+  echo "0.2.1"
+}
+
 # @info:    Prints the ascii logo
 asciiLogo ()
 {
@@ -136,7 +141,7 @@ setPropDefaults()
 # @info:    Parses and validates the CLI arguments
 parseCli()
 {
-
+  [ "$1" = "version" ] && version && exit
   [ "$#" -ge 1 ] || usage
 
   prop_machine_name=$1


### PR DESCRIPTION
Currently there is no way to know the version of the script once it is downloaded to local. 
For auto-updating purposes it is needed to have version of the script.

Appending version as a command allows other scripts to use it to easily determine docker-machine-nfs version installed.
