### PR TITLE
fix Adding mount with similar machine name causes error #66

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -333,8 +333,8 @@ configureNFS()
 
   #-- Update the /etc/exports file and restart nfsd
 
-  local exports_begin="# docker-machine-nfs-begin $prop_machine_name"
-  local exports_end="# docker-machine-nfs-end $prop_machine_name"
+  local exports_begin="# docker-machine-nfs-begin $prop_machine_name #"
+  local exports_end="# docker-machine-nfs-end $prop_machine_name #"
 
   # Remove old docker-machine-nfs exports
   local exports=$(cat /etc/exports | \


### PR DESCRIPTION
To fix this issue I had to add an extra character (#) at the end of each comment line. This means that if you would execute the script again (using -f) with a previous config in the exports file, it will create an extra entry. It will not break anything, but it does add duplications.
