### PR TITLE
Fix for VMware Fusion Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Options:
   -n, --nfs-config          NFS configuration to use in /etc/exports. (default to '-alldirs -mapall=\$(id -u):\$(id -g)')
   -s, --shared-folder,...   Folder to share (default to /Users)
   -m, --mount-opts          NFS mount options (default to 'noacl,async')
+  -i, --use-ip-range        Changes the nfs export ip to a range (e.g. -network 192.168.99.100 becomes -network 192.168.99)
 
 Examples:
 


### PR DESCRIPTION
When configuring a Docker machine for NFS mounts, the IP address in this
script differed from the IP given to my VMware VM. I've updated the
script to use the Docker machine IP, instead of 8.8.8.8. This causes the
`route get` command to return the proper `vmnet<#>` device instead of
whatever is tied to 8.8.8.8.

Also fixed the README.md file with the new `-i` option.