### PR TITLE
Use printf in favor of echo for reproducibility

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -360,7 +360,7 @@ configureNFS()
   # Write new exports block ending
   exports="${exports}${exports_end}"
   #Export to file
-  echo "$exports" | sudo tee /etc/exports >/dev/null
+  printf "$exports" | sudo tee /etc/exports >/dev/null
 
   sudo nfsd restart ; sleep 2 && sudo nfsd checkexports
 


### PR DESCRIPTION
In my machine, echo will lead to literally having \n in /etc/exports
file which will lead the nfs server to fail starting, this is due to the
echo version that I have locally, while printf doesn't have this issue
as explained here:
https://stackoverflow.com/questions/8467424/echo-newline-in-bash-prints-literal-n