### PR TITLE
Re-use method to find xhyve net ip for vmwarevsphere

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -292,11 +292,11 @@ lookupMandatoryProperties ()
     return
   fi
 
-  if [ "$prop_machine_driver" = "xhyve" ]; then
+  if [[ "$prop_machine_driver" =~ (xhyve|vmwarevsphere) ]]; then
     prop_network_id="Shared"
     prop_nfshost_ip=${prop_use_ip:-"$(ifconfig -m `route get $prop_machine_ip | awk '{if ($1 ~ /interface:/){print $2}}'` | awk 'sub(/inet /,""){print $1}')"}
     if [ "" = "${prop_nfshost_ip}" ]; then
-      echoError "Could not find the xhyve net IP!"; exit 1
+      echoError "Could not find a route to the ${prop_machine_driver} docker-machine"; exit 1
     fi
     echoSuccess "OK"
     return
@@ -309,18 +309,6 @@ lookupMandatoryProperties ()
 
     if [ "" = "${prop_nfshost_ip}" ]; then
       echoError "Could not find the parallels net IP!"; exit 1
-    fi
-
-    echoSuccess "OK"
-    return
-  fi
-
-  if [ "$prop_machine_driver" = "vmwarevsphere" ]; then
-    # Checks the routing table to find the ip address that your machine will use to connect to the docker-machine
-    prop_nfshost_ip=${prop_use_ip:-"$(ifconfig -m `route get $prop_machine_ip | awk '{if ($1 ~ /interface:/){print $2}}'` | awk 'sub(/inet /,""){print $1}')"}
-
-    if [ "" = "${prop_nfshost_ip}" ]; then
-      echoError "Could not find a route to the docker-machine!"; exit 1
     fi
 
     echoSuccess "OK"

--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -317,8 +317,7 @@ lookupMandatoryProperties ()
 
   if [ "$prop_machine_driver" = "vmwarevsphere" ]; then
     # Checks the routing table to find the ip address that your machine will use to connect to the docker-machine
-    machine_ip=$(netstat -rn -f inet | awk -v pattern="^$(route get ${prop_machine_ip} | grep gateway | awk '{print $2}')[^\/]" '$0 ~ pattern {print $2}')
-    prop_nfshost_ip=${prop_use_ip:-${machine_ip}}
+    prop_nfshost_ip=${prop_use_ip:-"$(ifconfig -m `route get $prop_machine_ip | awk '{if ($1 ~ /interface:/){print $2}}'` | awk 'sub(/inet /,""){print $1}')"}
 
     if [ "" = "${prop_nfshost_ip}" ]; then
       echoError "Could not find a route to the docker-machine!"; exit 1


### PR DESCRIPTION
Discovered that the method for finding the nfshost_ip for the xhyve driver can be reused for the vmwarevsphere driver.