### PR TITLE
add support for vmware fusion/workstation driver

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -266,7 +266,7 @@ lookupMandatoryProperties ()
 
   prop_machine_driver=$(getMachineDriver $1 "$2")
 
-  if [ "$prop_machine_driver" = "vmwarefusion" ]; then
+  if [ "$prop_machine_driver" = "vmwarefusion" ] || [ "$prop_machine_driver" = "vmware" ]; then
     prop_network_id="Shared"
     prop_nfshost_ip=${prop_use_ip:-"$(ifconfig -m `route get 8.8.8.8 | awk '{if ($1 ~ /interface:/){print $2}}'` | awk 'sub(/inet /,""){print $1}')"}
     prop_machine_ip=$prop_nfshost_ip


### PR DESCRIPTION
`lookupMandatoryProperties` will skip over the `vmware` driver when using the [docker-machine-driver-vmware](https://github.com/machine-drivers/docker-machine-driver-vmware)