### PR TITLE
Support docker-machine-driver-vmware and use machine ip for route

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -266,9 +266,9 @@ lookupMandatoryProperties ()
 
   prop_machine_driver=$(getMachineDriver $1 "$2")
 
-  if [ "$prop_machine_driver" = "vmwarefusion" ]; then
+  if [ "$prop_machine_driver" = "vmwarefusion" ] || [ "$prop_machine_driver" = "vmware" ]; then
     prop_network_id="Shared"
-    prop_nfshost_ip=${prop_use_ip:-"$(ifconfig -m `route get 8.8.8.8 | awk '{if ($1 ~ /interface:/){print $2}}'` | awk 'sub(/inet /,""){print $1}')"}
+    prop_nfshost_ip=${prop_use_ip:-"$(ifconfig -m `route get $prop_machine_ip | awk '{if ($1 ~ /interface:/){print $2}}'` | awk 'sub(/inet /,""){print $1}')"}
     prop_machine_ip=$prop_nfshost_ip
     if [ "" = "${prop_nfshost_ip}" ]; then
       echoError "Could not find the vmware fusion net IP!"; exit 1

--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -269,7 +269,6 @@ lookupMandatoryProperties ()
   if [ "$prop_machine_driver" = "vmwarefusion" ] || [ "$prop_machine_driver" = "vmware" ]; then
     prop_network_id="Shared"
     prop_nfshost_ip=${prop_use_ip:-"$(ifconfig -m `route get $prop_machine_ip | awk '{if ($1 ~ /interface:/){print $2}}'` | awk 'sub(/inet /,""){print $1}')"}
-    prop_machine_ip=$prop_nfshost_ip
     if [ "" = "${prop_nfshost_ip}" ]; then
       echoError "Could not find the vmware fusion net IP!"; exit 1
     fi


### PR DESCRIPTION
Add support for the new vmware driver for docker-machine https://github.com/machine-drivers/docker-machine-driver-vmware which supports vmware fusion 11.

Also fix the route detection for the docker-machine/nfs host ip address to improve security of the nfs export. This change makes it so the boot2docker vm only tries to access the nfs mount over the vmnet nat interface and have the nfs host only export the `/Users` directory to the docker machine in question instead of anyone having access to the host ip.

This also fixes an issue in a corporate environment where IPs can change based on connecting/disconnecting to/from a vpn.