### PR TITLE
Updated getting docker-machine properties

### DIFF
--- a/docker-machine-nfs.sh
+++ b/docker-machine-nfs.sh
@@ -225,7 +225,7 @@ checkMachinePresence ()
 {
   echoInfo "machine presence ... \t\t\t"
 
-  if [ "" = "$(docker-machine ls $2 | sed 1d | grep -w "$1")" ]; then
+  if [ "" = "$(docker-machine ls $2 --filter 'Name=^$1$' -q)" ]; then
     echoError "Could not find the machine '$1'!"; exit 1;
   fi
 
@@ -239,7 +239,7 @@ checkMachineRunning ()
 {
   echoInfo "machine running ... \t\t\t"
 
-  machine_state=$(docker-machine ls $2 | sed 1d | grep "^$1\s" | awk '{print $4}')
+  machine_state=$(docker-machine ls $2 --filter "Name=^$1$" --format "{{.State}}")
 
   if [ "Running" != "${machine_state}" ]; then
     echoError "The machine '$1' is not running but '${machine_state}'!";
@@ -254,7 +254,7 @@ checkMachineRunning ()
 # @return:  The driver used to create the machine
 getMachineDriver ()
 {
-  docker-machine ls $2 | sed 1d | grep "^$1\s" | awk '{print $3}'
+  docker-machine ls $2 --filter "Name=^$1$" --format "{{.DriverName}}"
 }
 
 # @info:    Loads mandatory properties from the docker machine


### PR DESCRIPTION
I've got an error when running docker-machine-nfs:
```
docker-machine-nfs default --shared-folder=/Users
[INFO] Configuration:

	- Machine Name: default 
	- Shared Folder: /Users
	- Mount Options: noacl,async 
	- Force: false 

[INFO] machine presence ... 			OK 
[INFO] machine running ... 			FAIL

The machine 'default' is not running but 'virtualbox'! 
```

When I checked, the reason was updated docker-machine which returns different count of columns compared to old versions.
So, I changed behavior to get these properties without grep-sed-awk magic, using only native docker-machine command line options.